### PR TITLE
change initial_time in settings to 2000-01-01

### DIFF
--- a/default_settings.json
+++ b/default_settings.json
@@ -65,7 +65,7 @@
         "general": {
             "button_ap_enabled": true,
             "button_ap_pin": "P2",
-            "initial_time": 1556805688,
+            "initial_time": 946684800,
             "measurement_interval": 5,
             "until_wifi_reconnect" : 12,
             "oled": false

--- a/settings_preset_clemens.json
+++ b/settings_preset_clemens.json
@@ -65,7 +65,7 @@
         "general": {
             "button_ap_enabled": false,
             "button_ap_pin": "",
-            "initial_time": 1556805688,
+            "initial_time": 946684800,
             "measurement_interval": 5,
             "until_wifi_reconnect" : 12,
             "oled": false

--- a/settings_preset_didi.json
+++ b/settings_preset_didi.json
@@ -65,7 +65,7 @@
         "general": {
             "button_ap_enabled": true,
             "button_ap_pin": "P2",
-            "initial_time": 1556805688,
+            "initial_time": 946684800,
             "measurement_interval": 5,
             "until_wifi_reconnect" : 12,
             "oled": false


### PR DESCRIPTION
Momentan ist die initiale Zeit fürs Logging auf SD gesetzt auf 
`"initial_time": 1556805688, `

Das ist aus Gründen, die nur die Götter (oder Vinz :-) kennen der 2. May 2019 14:01:28, so was ist verwirrend, weil es wie ein "richtiges" Datum ausschaut und es fällt nicht gleich auf, dass es eigentlich willkürlich gesetzt ist. 

Können wir das mit 

946684800 
(1. January 2000 00:00:00)

(alternativ auch 0 (1. January 1970 00:00:00))

in
```
default_settings.json
settings_preset_clemens.json
settings_preset_didi.json
```

ersetzen. Dann ist es etwas offensichtlicher, dass hier das Datum noch nicht gesetzt wurde. 